### PR TITLE
Enabling ace revive

### DIFF
--- a/t1_ace_settings/config.cpp
+++ b/t1_ace_settings/config.cpp
@@ -355,17 +355,17 @@ class ACE_Settings {
 		force = 0;
 	};
 	class ace_medical_enableRevive {
-		value = 0;
+		value = 1;
 		typeName = "SCALAR";
 		force = 0;
 	};
 	class ace_medical_maxReviveTime {
-		value = 600;
+		value = 1200;
 		typeName = "SCALAR";
 		force = 0;
 	};
 	class ace_medical_amountOfReviveLives {
-		value = 2;
+		value = -1;
 		typeName = "SCALAR";
 		force = 0;
 	};


### PR DESCRIPTION
Proposed by request so that you cannot die in game no matter the amount of damage sustained. Allowing interesting situations to develop in game where you can get bogged down with a casualty and freeing mission makers from re spawn duty.
